### PR TITLE
Link pthread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(GPHOTO2PP_SOURCES ${GPHOTO2PP_SOURCE_FILES})
 set(GPHOTO2PP_HEADERS ${GPHOTO2PP_HPPHEADER_FILES} ${GPHOTO2PP_HEADER_FILES})
 
 add_library( gphoto2pp SHARED ${GPHOTO2PP_SOURCES})
+target_link_libraries(gphoto2pp pthread)
 
 include_directories("include")
 


### PR DESCRIPTION
Building (any of the) examples fails with the following error:
/usr/bin/ld: ../libs/libgphoto2pp.so.1.0.0: undefined reference to `pthread_create'

Linking to pthread solves this issue.

Thank you for providing this library, it is very nice and easy to use.