### PR TITLE
Clean up correct folder when doing release build.

### DIFF
--- a/cmake_release.sh
+++ b/cmake_release.sh
@@ -7,7 +7,7 @@ set -e
 if [ -d "./build/release/" ]; then
 	echo "Release build found, cleaning up..."
 	cd ./build/
-	rm -rf -- debug/
+	rm -rf -- release/
 	mkdir release
 	cd release
 	cmake -DCMAKE_BUILD_TYPE=RELEASE ../../


### PR DESCRIPTION
Previously code was trying to clean up the debug build directory instead.